### PR TITLE
fix: Jobserver.ParseNativeMakeFlagsValue test on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+Kitware maintains this branch of Ninja in order to provide features
+that have not been integrated and released upstream:
+
+* jobserver pipe mode support
+
+This branch may be *rebased* without notice for maintenance on top of
+the upstream `master` branch.
+
+Parts of this branch have been rejected from upstream consideration:
+
+* https://github.com/ninja-build/ninja/pull/2506#issuecomment-2659944455
+
+-----------------------------------------------------------------------------
+
 # Ninja
 
 Ninja is a small build system with a focus on speed.

--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -207,7 +207,8 @@ This feature is automatically enabled under the following conditions:
 
 - The `MAKEFLAGS` environment variable is defined and describes a valid
   jobserver mode using `--jobserver-auth=SEMAPHORE_NAME` on Windows, or
-  `--jobserver-auth=fifo:PATH` on Posix.
+  `--jobserver-auth=fifo:PATH`, `--jobserver-auth=<read>,<write>`, or
+  even `--jobserver-fds=R,W` on Posix.
 
 In this case, Ninja will use the jobserver pool of job slots to control
 parallelism, instead of its default parallel implementation.
@@ -215,11 +216,9 @@ parallelism, instead of its default parallel implementation.
 Note that load-average limitations (i.e. when using `-l<count>`)
 are still being enforced in this mode.
 
-IMPORTANT: On Posix, only the FIFO-based version of the protocol, which is
-implemented by GNU Make 4.4 and higher, is supported. Ninja will detect
-when a pipe-based jobserver is being used (i.e. when `MAKEFLAGS` contains
-`--jobserver-auth=<read>,<write>`) and will print a warning, but will
-otherwise ignore it.
+IMPORTANT: On Posix, the FIFO-based version of the protocol, which is
+implemented by GNU Make 4.4 and higher, is preferred. Ninja will warn
+when a pipe-based jobserver is being used.
 
 Environment variables
 ~~~~~~~~~~~~~~~~~~~~~

--- a/misc/jobserver_test.py
+++ b/misc/jobserver_test.py
@@ -253,42 +253,7 @@ class JobserverTest(unittest.TestCase):
 
     @unittest.skipIf(_PLATFORM_IS_WINDOWS, "These test methods do not work on Windows")
     def test_jobserver_client_with_posix_pipe(self):
-        # Verify that setting up a --pipe server does not make Ninja exit with an error.
-        # Instead, a warning is printed.
-        task_count = 4
-        build_plan = generate_build_plan(task_count)
-        with BuildDir(build_plan) as b:
-
-            prefix_args = [
-                sys.executable,
-                "-S",
-                _JOBSERVER_POOL_SCRIPT,
-                "--pipe",
-                f"--jobs={task_count}",
-            ]
-
-            def run_ninja_with_jobserver_pipe(args):
-                ret = b.ninja_spawn(args, prefix_args=prefix_args)
-                ret.check_returncode()
-                return ret.stdout, ret.stderr
-
-            output, error = run_ninja_with_jobserver_pipe(["all"])
-            if _DEBUG:
-                print(f"OUTPUT [{output}]\nERROR [{error}]\n", file=sys.stderr)
-            self.assertTrue(error.find("Pipe-based protocol is not supported!") >= 0)
-
-            max_overlaps = compute_max_overlapped_spans(b.path, task_count)
-            self.assertEqual(max_overlaps, task_count)
-
-            # Using an explicit -j<N> ignores the jobserver pool.
-            b.ninja_clean()
-            output, error = run_ninja_with_jobserver_pipe(["-j1", "all"])
-            if _DEBUG:
-                print(f"OUTPUT [{output}]\nERROR [{error}]\n", file=sys.stderr)
-            self.assertFalse(error.find("Pipe-based protocol is not supported!") >= 0)
-
-            max_overlaps = compute_max_overlapped_spans(b.path, task_count)
-            self.assertEqual(max_overlaps, 1)
+        self._run_client_test([sys.executable, "-S", _JOBSERVER_POOL_SCRIPT, "--pipe"])
 
     def _test_MAKEFLAGS_value(
         self, ninja_args: T.List[str] = [], prefix_args: T.List[str] = []

--- a/src/jobserver-posix.cc
+++ b/src/jobserver-posix.cc
@@ -33,6 +33,41 @@ bool IsFifoDescriptor(int fd) {
   return (ret == 0) && ((info.st_mode & S_IFMT) == S_IFIFO);
 }
 
+bool SetNonBlockingFd(int fd) {
+  int flags = fcntl(fd, F_GETFL, 0);
+  if (!(flags & O_NONBLOCK)) {
+    int ret = fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+    if (ret < 0)
+      return false;
+  }
+  return true;
+}
+
+bool SetCloseOnExecFd(int fd) {
+  int flags = fcntl(fd, F_GETFD, 0);
+  if (!(flags & FD_CLOEXEC)) {
+    int ret = fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
+    if (ret < 0)
+      return false;
+  }
+  return true;
+}
+
+// Duplicate the descriptor and make the result non-blocking and
+// close-on-exec.
+bool DuplicateDescriptor(int from_fd, int* to_fd) {
+  int new_fd = dup(from_fd);
+  if (new_fd < 0) {
+    return false;
+  }
+  if (!SetNonBlockingFd(new_fd) || !SetCloseOnExecFd(new_fd)) {
+    ::close(new_fd);
+    return false;
+  }
+  *to_fd = new_fd;
+  return true;
+}
+
 // Implementation of Jobserver::Client for Posix systems
 class PosixJobserverClient : public Jobserver::Client {
  public:
@@ -75,6 +110,28 @@ class PosixJobserverClient : public Jobserver::Client {
       ret = ::write(write_fd_, &slot_char, 1);
     } while (ret < 0 && errno == EINTR);
     (void)ret;  // Nothing can be done in case of error here.
+  }
+
+  // Initialize instance with two explicit pipe file descriptors.
+  bool InitWithPipeFds(int read_fd, int write_fd, std::string* error) {
+    // Verify that the file descriptors belong to FIFOs.
+    if (!IsFifoDescriptor(read_fd) || !IsFifoDescriptor(write_fd)) {
+      *error = "Invalid file descriptors";
+      return false;
+    }
+    // Duplicate the file descriptors to make then non-blocking, and
+    // close-on-exec. This is important because the original descriptors
+    // might be inherited by sub-processes of this client.
+    if (!DuplicateDescriptor(read_fd, &read_fd_)) {
+      *error = "Could not duplicate read descriptor";
+      return false;
+    }
+    if (!DuplicateDescriptor(write_fd, &write_fd_)) {
+      *error = "Could not duplicate write descriptor";
+      // Let destructor close read_fd_.
+      return false;
+    }
+    return true;
   }
 
   // Initialize with FIFO file path.
@@ -122,6 +179,8 @@ std::unique_ptr<Jobserver::Client> Jobserver::Client::Create(
   auto client = std::unique_ptr<PosixJobserverClient>(new PosixJobserverClient);
   if (config.mode == Jobserver::Config::kModePosixFifo) {
     success = client->InitWithFifo(config.path, error);
+  } else if (config.mode == Jobserver::Config::kModePipe) {
+    success = client->InitWithPipeFds(config.read_fd, config.write_fd, error);
   } else {
     *error = "Unsupported jobserver mode";
   }

--- a/src/jobserver.cc
+++ b/src/jobserver.cc
@@ -37,18 +37,16 @@ bool GetPrefixedValue(StringPiece input, StringPiece prefix,
 
 // Try to read a comma-separated pair of file descriptors from |input|.
 // On success return true and set |config->mode| accordingly. Otherwise return
-// false if the input doesn't follow the appropriate format. Note that the
-// values are not saved since pipe mode is not supported.
+// false if the input doesn't follow the appropriate format.
 bool GetFileDescriptorPair(StringPiece input, Jobserver::Config* config) {
-  int read_fd = 1, write_fd = -1;
   std::string pair = input.AsString();
-  if (sscanf(pair.c_str(), "%d,%d", &read_fd, &write_fd) != 2)
+  if (sscanf(pair.c_str(), "%d,%d", &config->read_fd, &config->write_fd) != 2)
     return false;
 
   // From
   // https://www.gnu.org/software/make/manual/html_node/POSIX-Jobserver.html Any
   // negative descriptor means the feature is disabled.
-  if (read_fd < 0 || write_fd < 0)
+  if (config->read_fd < 0 || config->write_fd < 0)
     config->mode = Jobserver::Config::kModeNone;
   else
     config->mode = Jobserver::Config::kModePipe;
@@ -189,13 +187,13 @@ bool Jobserver::ParseNativeMakeFlagsValue(const char* makeflags_env,
   if (!ParseMakeFlagsValue(makeflags_env, config, error))
     return false;
 
-  if (config->mode == Jobserver::Config::kModePipe) {
-    *error = "Pipe-based protocol is not supported!";
-    return false;
-  }
 #ifdef _WIN32
   if (config->mode == Jobserver::Config::kModePosixFifo) {
     *error = "FIFO mode is not supported on Windows!";
+    return false;
+  }
+  if (config->mode == Jobserver::Config::kModePipe) {
+    *error = "Pipe mode is not supported on Windows!";
     return false;
   }
 #else   // !_WIN32

--- a/src/jobserver.h
+++ b/src/jobserver.h
@@ -111,8 +111,7 @@ struct Jobserver {
     /// kModePipe means that `--jobserver-auth=R,W` is used to
     ///    pass a pair of file descriptors to client processes. This also
     ///    matches `--jobserver-fds=R,W` which is an old undocumented
-    ///    variant of the same scheme. This mode is not supported by
-    ///    Ninja, but recognized by the parser.
+    ///    variant of the same scheme.
     ///
     /// kModePosixFifo means that `--jobserver-auth=fifo:PATH` is used to
     ///    pass the path of a Posix FIFO to client processes. This is not
@@ -144,6 +143,11 @@ struct Jobserver {
     /// For kModeFifo, this is the path to the Unix FIFO to use.
     /// For kModeSemaphore, this is the name of the Win32 semaphore to use.
     std::string path;
+
+    /// For kModePipe, these are the file descriptor values
+    /// extracted from MAKEFLAGS.
+    int read_fd = -1;
+    int write_fd = -1;
 
     /// Return true if this instance matches an active implementation mode.
     /// This does not try to validate configuration parameters though.

--- a/src/jobserver_test.cc
+++ b/src/jobserver_test.cc
@@ -151,6 +151,8 @@ TEST(Jobserver, ParseMakeFlagsValue) {
   ASSERT_TRUE(Jobserver::ParseMakeFlagsValue("--jobserver-auth=10,42", &config,
                                              &error));
   EXPECT_EQ(Jobserver::Config::kModePipe, config.mode);
+  EXPECT_EQ(10, config.read_fd);
+  EXPECT_EQ(42, config.write_fd);
 
   config = {};
   error.clear();
@@ -187,9 +189,11 @@ TEST(Jobserver, ParseNativeMakeFlagsValue) {
   // --jobserver-auth=R,W is not supported.
   config = {};
   error.clear();
-  EXPECT_FALSE(Jobserver::ParseNativeMakeFlagsValue("--jobserver-auth=3,4",
-                                                    &config, &error));
-  EXPECT_EQ(error, "Pipe-based protocol is not supported!");
+  EXPECT_TRUE(Jobserver::ParseNativeMakeFlagsValue("--jobserver-auth=3,4",
+                                                   &config, &error));
+  EXPECT_EQ(Jobserver::Config::kModePipe, config.mode);
+  EXPECT_EQ(3, config.read_fd);
+  EXPECT_EQ(4, config.write_fd);
 
 #ifdef _WIN32
   // --jobserver-auth=NAME works on Windows.

--- a/src/jobserver_test.cc
+++ b/src/jobserver_test.cc
@@ -186,7 +186,15 @@ TEST(Jobserver, ParseNativeMakeFlagsValue) {
   Jobserver::Config config;
   std::string error;
 
-  // --jobserver-auth=R,W is not supported.
+#ifdef _WIN32
+  // --jobserver-auth=R,W is not supported on Windows.
+  config = {};
+  error.clear();
+  EXPECT_FALSE(Jobserver::ParseNativeMakeFlagsValue("--jobserver-auth=3,4",
+                                                    &config, &error));
+  EXPECT_EQ(error, "Pipe mode is not supported on Windows!");
+#else   // !_WIN32
+  // --jobserver-auth=R,W supported on Posix.
   config = {};
   error.clear();
   EXPECT_TRUE(Jobserver::ParseNativeMakeFlagsValue("--jobserver-auth=3,4",
@@ -194,6 +202,7 @@ TEST(Jobserver, ParseNativeMakeFlagsValue) {
   EXPECT_EQ(Jobserver::Config::kModePipe, config.mode);
   EXPECT_EQ(3, config.read_fd);
   EXPECT_EQ(4, config.write_fd);
+#endif  // !_WIN32
 
 #ifdef _WIN32
   // --jobserver-auth=NAME works on Windows.

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -1578,6 +1578,13 @@ std::unique_ptr<Jobserver::Client> NinjaMain::SetupJobserverClient(
 
   if (config_.verbosity > BuildConfig::NO_STATUS_UPDATE) {
     status->Info("Jobserver mode detected: %s", makeflags);
+#ifndef _WIN32
+    if (jobserver_config.mode == Jobserver::Config::kModePipe) {
+      status->Warning(
+          "Jobserver 'pipe' mode detected, a pool that implements 'fifo' mode "
+          "would be more reliable!");
+    }
+#endif
   }
 
   result = Jobserver::Client::Create(jobserver_config, &err);

--- a/src/version.cc
+++ b/src/version.cc
@@ -20,7 +20,7 @@
 
 using namespace std;
 
-const char* kNinjaVersion = "1.13.0";
+const char* kNinjaVersion = "1.13.0.git.kitware.jobserver-pipe-1";
 
 void ParseVersion(const string& version, int* major, int* minor) {
   size_t end = version.find('.');


### PR DESCRIPTION
This PR fixes the Jobserver.ParseNativeMakeFlagsValue test failure on Windows specific to the Kitware fork.
Issue found while working on https://github.com/scikit-build/ninja-python-distributions/pull/305#issuecomment-3146299285
The fix has been [tested in CI](
https://github.com/mayeut/ninja-python-distributions/actions/runs/16691899082) using the following diff for ninja-python-distributions:
```diff
diff --git a/.gitmodules b/.gitmodules
index fa0442c..7983d13 100644
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ninja-upstream"]
        path = ninja-upstream
-       url = https://github.com/Kitware/ninja.git
+       url = https://github.com/mayeut/kitware-ninja.git
diff --git a/ninja-upstream b/ninja-upstream
index d74efef..c12e96c 160000
--- a/ninja-upstream
+++ b/ninja-upstream
@@ -1 +1 @@
-Subproject commit d74efef9fa331d3ae60b62479d49254827c081fe
+Subproject commit c12e96cab1fc7076c71855dbbe4c46a87206cb2b
diff --git a/pyproject.toml b/pyproject.toml
index 63b533a..1df2eca 100644
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,11 +142,6 @@ select = "*_s390x"
 inherit.config-settings = "append"
 config-settings = {"cmake.define.TEST_OPTS" = "--gtest_filter=-DepsLogTest.MalformedDepsLog"}
 
-# Doesn't account for platform in 1.13.0 https://github.com/scikit-build/ninja-python-distributions/pull/305#issuecomment-3146299285
-[[tool.cibuildwheel.overrides]]
-select = "*-win*"
-inherit.config-settings = "append"
-config-settings = {"cmake.define.TEST_OPTS" = "--gtest_filter=-Jobserver.ParseNativeMakeFlagsValue"}
 
 
 [tool.pytest.ini_options]

```